### PR TITLE
Simplified header management, more accurate timestamps and more complete event payload

### DIFF
--- a/Castle.podspec
+++ b/Castle.podspec
@@ -21,6 +21,7 @@ Castle for iOS provides a simple way to integrate Castle into your app.
   s.source           = { :git => 'https://github.com/castle/castle-ios.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'
+  s.ios.frameworks = 'Security'
 
   s.source_files = 'Castle/Classes/**/*'
 end

--- a/Castle/Classes/CASContext.h
+++ b/Castle/Classes/CASContext.h
@@ -1,0 +1,14 @@
+//
+//  CASContext.h
+//  Castle
+//
+//  Created by Alexander Simson on 2018-02-12.
+//
+
+#import "CASDevice.h"
+
+@interface CASContext : CASModel
+
++ (instancetype)sharedContext;
+
+@end

--- a/Castle/Classes/CASContext.m
+++ b/Castle/Classes/CASContext.m
@@ -53,7 +53,7 @@
     context[@"os"] = @{ @"name": [[UIDevice currentDevice] systemName],
                         @"version": [[UIDevice currentDevice] systemVersion] };
     
-    context[@"library"] = @{ @"name": @"Castle iOS",
+    context[@"library"] = @{ @"name": @"castle-ios",
                              @"version": [Castle versionString] };
     
     return context;

--- a/Castle/Classes/CASContext.m
+++ b/Castle/Classes/CASContext.m
@@ -1,0 +1,62 @@
+//
+//  CASContext.m
+//  Castle
+//
+//  Created by Alexander Simson on 2018-02-12.
+//
+
+#import "CASContext.h"
+
+#import "CASReachability.h"
+#import "Castle+Util.h"
+
+@implementation CASContext
+
++ (instancetype)sharedContext
+{
+    static CASContext *_sharedContext = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _sharedContext = [[CASContext alloc] init];
+    });
+    return _sharedContext;
+}
+
+#pragma mark - CASModel
+
+- (id)JSONPayload
+{
+    NSMutableDictionary *context = [NSMutableDictionary dictionaryWithObject:[[CASDevice sharedDevice] JSONPayload] forKey:@"device"];
+    
+    context[@"timezone"] = [NSTimeZone systemTimeZone].name;
+    
+    NSLocale *locale = [NSLocale currentLocale];
+    context[@"locale"] = [NSString stringWithFormat:@"%@-%@", [locale objectForKey:NSLocaleLanguageCode], [locale objectForKey:NSLocaleCountryCode]];
+    
+    context[@"network"] = ({
+        NSMutableDictionary *network = [NSMutableDictionary dictionary];
+        network[@"wifi"] = @([Castle isWifiAvailable]);
+        network[@"cellular"] = @([Castle isCellularAvailable]);
+        
+        if([Castle isCellularAvailable]) {
+            network[@"carrier"] = [Castle carrierName];
+        }
+        network;
+    });
+    
+    context[@"timezone"] = [[NSTimeZone localTimeZone] name];
+    
+    context[@"screen"] = @{ @"width": @([UIScreen mainScreen].bounds.size.width),
+                            @"height": @([UIScreen mainScreen].bounds.size.height),
+                            @"density": @([UIScreen mainScreen].scale) };
+    
+    context[@"os"] = @{ @"name": [[UIDevice currentDevice] systemName],
+                        @"version": [[UIDevice currentDevice] systemVersion] };
+    
+    context[@"library"] = @{ @"name": @"Castle iOS",
+                             @"version": [Castle versionString] };
+    
+    return context;
+}
+
+@end

--- a/Castle/Classes/CASDevice.m
+++ b/Castle/Classes/CASDevice.m
@@ -32,8 +32,6 @@
               @"manufacturer": @"Apple",
               @"id": [Castle deviceIdentifier],
               @"name": [[UIDevice currentDevice] name],
-              @"system": [[UIDevice currentDevice] systemName],
-              @"system_version": [[UIDevice currentDevice] systemVersion],
               @"type": UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? @"tablet" : @"phone" };
 }
 

--- a/Castle/Classes/CASIdentity.m
+++ b/Castle/Classes/CASIdentity.m
@@ -7,7 +7,7 @@
 
 #import "CASIdentity.h"
 
-#import "CASDevice.h"
+#import "CASContext.h"
 #import "CASUtils.h"
 
 @interface CASIdentity ()
@@ -51,7 +51,7 @@
 - (id)JSONPayload
 {
     NSString *timestamp = [[CASModel timestampDateFormatter] stringFromDate:self.timestamp];
-    NSDictionary *context = @{ @"device": [[CASDevice sharedDevice] JSONPayload] };
+    NSDictionary *context = [[CASContext sharedContext] JSONPayload];
 
     return @{ @"type": @"identify",
               @"user_id": self.userId,

--- a/Castle/Classes/CASModel.m
+++ b/Castle/Classes/CASModel.m
@@ -26,6 +26,11 @@
         if(error != nil) {
             CASLog(@"Seralization of object (%@) failed with error: %@", NSStringFromClass(self.class), error);
         }
+        
+        NSString *jsonString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        jsonString = [jsonString stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
+        data = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
+        
         return data;
     }
     return nil;

--- a/Castle/Classes/CASModel.m
+++ b/Castle/Classes/CASModel.m
@@ -43,7 +43,7 @@
     dispatch_once(&onceToken, ^{
         _timestampDateFormatter = [[NSDateFormatter alloc] init];
         [_timestampDateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
-        [_timestampDateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+        [_timestampDateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
     });
     return _timestampDateFormatter;
 }

--- a/Castle/Classes/CASRequestInterceptor.m
+++ b/Castle/Classes/CASRequestInterceptor.m
@@ -49,10 +49,8 @@ static NSString *CASRecursiveRequestFlagProperty = @"com.castle.CASRequestInterc
     NSMutableURLRequest *newRequest = [self.request mutableCopy];
     [NSURLProtocol setProperty:@YES forKey:CASRecursiveRequestFlagProperty inRequest:newRequest];
     
-    // Set custom headers
-    [[Castle headers] enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL* stop) {
-        [newRequest setValue:value forHTTPHeaderField:key];
-    }];
+    // Set custom header
+    [newRequest setValue:[Castle deviceIdentifier] forHTTPHeaderField:CASCastleDeviceIdHeaderKey];
     
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
     config.protocolClasses = [config.protocolClasses arrayByAddingObject:self.class];
@@ -74,10 +72,8 @@ static NSString *CASRecursiveRequestFlagProperty = @"com.castle.CASRequestInterc
     if (response) {
         NSMutableURLRequest *redirectRequest = [newRequest mutableCopy];
         
-        // Set custom headers
-        [[Castle headers] enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL* stop) {
-            [redirectRequest setValue:value forHTTPHeaderField:key];
-        }];
+        // Set custom header
+        [redirectRequest setValue:[Castle deviceIdentifier] forHTTPHeaderField:CASCastleDeviceIdHeaderKey];
         
         [[self client] URLProtocol:self wasRedirectedToRequest:redirectRequest redirectResponse:response];
         

--- a/Castle/Classes/CASScreen.m
+++ b/Castle/Classes/CASScreen.m
@@ -8,7 +8,7 @@
 #import "CASScreen.h"
 
 #import "Castle.h"
-#import "CASDevice.h"
+#import "CASContext.h"
 #import "CASUtils.h"
 
 @interface CASScreen ()
@@ -60,7 +60,7 @@
 - (id)JSONPayload
 {
     NSString *timestamp = [[CASModel timestampDateFormatter] stringFromDate:self.timestamp];
-    NSDictionary *context = @{ @"device": [[CASDevice sharedDevice] JSONPayload] };
+    NSDictionary *context = [[CASContext sharedContext] JSONPayload];
     
     NSMutableDictionary *payload = @{ @"type": self.type,
                                       @"name": self.name,

--- a/Castle/Classes/Castle+Util.h
+++ b/Castle/Classes/Castle+Util.h
@@ -1,0 +1,16 @@
+//
+//  Castle+Util.h
+//  Castle
+//
+//  Created by Alexander Simson on 2018-02-12.
+//
+
+#import <Castle/Castle.h>
+
+@interface Castle (Util)
+
++ (BOOL)isWifiAvailable;
++ (BOOL)isCellularAvailable;
++ (NSString *)carrierName;
+
+@end

--- a/Castle/Classes/Client/CASEvent.m
+++ b/Castle/Classes/Client/CASEvent.m
@@ -8,7 +8,7 @@
 #import "CASEvent.h"
 
 #import "CASUtils.h"
-#import "CASDevice.h"
+#import "CASContext.h"
 #import "Castle.h"
 
 @interface CASEvent ()
@@ -83,7 +83,7 @@
 - (id)JSONPayload
 {
     NSString *timestamp = [[CASModel timestampDateFormatter] stringFromDate:self.timestamp];
-    NSDictionary *context = @{ @"device": [[CASDevice sharedDevice] JSONPayload] };
+    NSDictionary *context = [[CASContext sharedContext] JSONPayload];
 
     NSMutableDictionary *payload = @{ @"type": self.type,
                                       @"event": self.name,

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -36,6 +36,7 @@ FOUNDATION_EXPORT const unsigned char CastleVersionString[];
 + (void)screen:(NSString *)eventName properties:(NSDictionary *)properties;
 
 + (void)flush;
++ (void)flushIfNeeded:(NSURL *)url;
 + (void)reset;
 
 + (BOOL)isWhitelistURL:(NSURL *)url;

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -15,6 +15,8 @@ FOUNDATION_EXPORT const unsigned char CastleVersionString[];
 
 #import "CastleConfiguration.h"
 
+extern NSString *const CASCastleDeviceIdHeaderKey;
+
 @interface Castle : NSObject
 
 + (NSString *)versionString;
@@ -45,6 +47,5 @@ FOUNDATION_EXPORT const unsigned char CastleVersionString[];
     
 + (NSString *)deviceIdentifier;
 + (NSString *)userIdentity;
-+ (NSDictionary <NSString *, NSString *> *)headers;
     
 @end

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -17,6 +17,8 @@ FOUNDATION_EXPORT const unsigned char CastleVersionString[];
 
 @interface Castle : NSObject
 
++ (NSString *)versionString;
+
 #pragma mark - Configuration
     
 + (void)setupWithConfiguration:(CastleConfiguration *)configuration;

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -144,12 +144,6 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     return _userIdentity;
 }
 
-+ (NSDictionary <NSString *, id> *)headers
-{
-    Castle *castle = [Castle sharedInstance];
-    return @{ CASCastleDeviceIdHeaderKey: castle.deviceIdentifier };
-}
-
 + (BOOL)isWifiAvailable
 {
     return [Castle sharedInstance].reachability.isReachableViaWiFi;

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -289,6 +289,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [castle.task resume];
 }
 
++ (void)flushIfNeeded:(NSURL *)url
+{
+    if([self isWhitelistURL:url]) {
+        [self flush];
+    }
+}
+
 + (void)reset
 {
     Castle *castle = [Castle sharedInstance];

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -26,7 +26,7 @@
 NSString *const CastleUserIdentifierKey = @"CastleUserIdentifierKey";
 NSString *const CastleAppVersionKey = @"CastleAppVersionKey";
 
-static NSString *CASCastleDeviceIdHeaderKey = @"X-Castle-Client-Id";
+NSString *const CASCastleDeviceIdHeaderKey = @"X-Castle-Client-Id";
 
 static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 

--- a/Castle/Classes/Reachability/CASReachability.h
+++ b/Castle/Classes/Reachability/CASReachability.h
@@ -1,0 +1,102 @@
+/*
+ Copyright (c) 2011, Tony Million.
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ 
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#import <Foundation/Foundation.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+
+//! Project version number for MacOSReachability.
+FOUNDATION_EXPORT double ReachabilityVersionNumber;
+
+//! Project version string for MacOSReachability.
+FOUNDATION_EXPORT const unsigned char ReachabilityVersionString[];
+
+/** 
+ * Create NS_ENUM macro if it does not exist on the targeted version of iOS or OS X.
+ *
+ * @see http://nshipster.com/ns_enum-ns_options/
+ **/
+#ifndef NS_ENUM
+#define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+#endif
+
+extern NSString *const kReachabilityChangedNotification;
+
+typedef NS_ENUM(NSInteger, NetworkStatus) {
+    // Apple NetworkStatus Compatible Names.
+    NotReachable = 0,
+    ReachableViaWiFi = 2,
+    ReachableViaWWAN = 1
+};
+
+@class CASReachability;
+
+typedef void (^NetworkReachable)(CASReachability * reachability);
+typedef void (^NetworkUnreachable)(CASReachability * reachability);
+typedef void (^NetworkReachability)(CASReachability * reachability, SCNetworkConnectionFlags flags);
+
+
+@interface CASReachability : NSObject
+
+@property (nonatomic, copy) NetworkReachable    reachableBlock;
+@property (nonatomic, copy) NetworkUnreachable  unreachableBlock;
+@property (nonatomic, copy) NetworkReachability reachabilityBlock;
+
+@property (nonatomic, assign) BOOL reachableOnWWAN;
+
+
++(instancetype)reachabilityWithHostname:(NSString*)hostname;
+// This is identical to the function above, but is here to maintain
+//compatibility with Apples original code. (see .m)
++(instancetype)reachabilityWithHostName:(NSString*)hostname;
++(instancetype)reachabilityForInternetConnection;
++(instancetype)reachabilityWithAddress:(void *)hostAddress;
++(instancetype)reachabilityForLocalWiFi;
+
+-(instancetype)initWithReachabilityRef:(SCNetworkReachabilityRef)ref;
+
+-(BOOL)startNotifier;
+-(void)stopNotifier;
+
+-(BOOL)isReachable;
+-(BOOL)isReachableViaWWAN;
+-(BOOL)isReachableViaWiFi;
+
+// WWAN may be available, but not active until a connection has been established.
+// WiFi may require a connection for VPN on Demand.
+-(BOOL)isConnectionRequired; // Identical DDG variant.
+-(BOOL)connectionRequired; // Apple's routine.
+// Dynamic, on demand connection?
+-(BOOL)isConnectionOnDemand;
+// Is user intervention required?
+-(BOOL)isInterventionRequired;
+
+-(NetworkStatus)currentReachabilityStatus;
+-(SCNetworkReachabilityFlags)reachabilityFlags;
+-(NSString*)currentReachabilityString;
+-(NSString*)currentReachabilityFlags;
+
+@end

--- a/Castle/Classes/Reachability/CASReachability.m
+++ b/Castle/Classes/Reachability/CASReachability.m
@@ -1,0 +1,475 @@
+/*
+ Copyright (c) 2011, Tony Million.
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ 
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#import "CASReachability.h"
+
+#import <sys/socket.h>
+#import <netinet/in.h>
+#import <netinet6/in6.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
+
+
+NSString *const kReachabilityChangedNotification = @"kReachabilityChangedNotification";
+
+
+@interface CASReachability ()
+
+@property (nonatomic, assign) SCNetworkReachabilityRef  reachabilityRef;
+@property (nonatomic, strong) dispatch_queue_t          reachabilitySerialQueue;
+@property (nonatomic, strong) id                        reachabilityObject;
+
+-(void)reachabilityChanged:(SCNetworkReachabilityFlags)flags;
+-(BOOL)isReachableWithFlags:(SCNetworkReachabilityFlags)flags;
+
+@end
+
+
+static NSString *reachabilityFlags(SCNetworkReachabilityFlags flags) 
+{
+    return [NSString stringWithFormat:@"%c%c %c%c%c%c%c%c%c",
+#if	TARGET_OS_IPHONE
+            (flags & kSCNetworkReachabilityFlagsIsWWAN)               ? 'W' : '-',
+#else
+            'X',
+#endif
+            (flags & kSCNetworkReachabilityFlagsReachable)            ? 'R' : '-',
+            (flags & kSCNetworkReachabilityFlagsConnectionRequired)   ? 'c' : '-',
+            (flags & kSCNetworkReachabilityFlagsTransientConnection)  ? 't' : '-',
+            (flags & kSCNetworkReachabilityFlagsInterventionRequired) ? 'i' : '-',
+            (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic)  ? 'C' : '-',
+            (flags & kSCNetworkReachabilityFlagsConnectionOnDemand)   ? 'D' : '-',
+            (flags & kSCNetworkReachabilityFlagsIsLocalAddress)       ? 'l' : '-',
+            (flags & kSCNetworkReachabilityFlagsIsDirect)             ? 'd' : '-'];
+}
+
+// Start listening for reachability notifications on the current run loop
+static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void* info) 
+{
+#pragma unused (target)
+
+    CASReachability *reachability = ((__bridge CASReachability*)info);
+
+    // We probably don't need an autoreleasepool here, as GCD docs state each queue has its own autorelease pool,
+    // but what the heck eh?
+    @autoreleasepool 
+    {
+        [reachability reachabilityChanged:flags];
+    }
+}
+
+
+@implementation CASReachability
+
+#pragma mark - Class Constructor Methods
+
++(instancetype)reachabilityWithHostName:(NSString*)hostname
+{
+    return [CASReachability reachabilityWithHostname:hostname];
+}
+
++(instancetype)reachabilityWithHostname:(NSString*)hostname
+{
+    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithName(NULL, [hostname UTF8String]);
+    if (ref) 
+    {
+        id reachability = [[self alloc] initWithReachabilityRef:ref];
+
+        return reachability;
+    }
+    
+    return nil;
+}
+
++(instancetype)reachabilityWithAddress:(void *)hostAddress
+{
+    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr*)hostAddress);
+    if (ref) 
+    {
+        id reachability = [[self alloc] initWithReachabilityRef:ref];
+        
+        return reachability;
+    }
+    
+    return nil;
+}
+
++(instancetype)reachabilityForInternetConnection
+{
+    struct sockaddr_in zeroAddress;
+    bzero(&zeroAddress, sizeof(zeroAddress));
+    zeroAddress.sin_len = sizeof(zeroAddress);
+    zeroAddress.sin_family = AF_INET;
+    
+    return [self reachabilityWithAddress:&zeroAddress];
+}
+
++(instancetype)reachabilityForLocalWiFi
+{
+    struct sockaddr_in localWifiAddress;
+    bzero(&localWifiAddress, sizeof(localWifiAddress));
+    localWifiAddress.sin_len            = sizeof(localWifiAddress);
+    localWifiAddress.sin_family         = AF_INET;
+    // IN_LINKLOCALNETNUM is defined in <netinet/in.h> as 169.254.0.0
+    localWifiAddress.sin_addr.s_addr    = htonl(IN_LINKLOCALNETNUM);
+    
+    return [self reachabilityWithAddress:&localWifiAddress];
+}
+
+
+// Initialization methods
+
+-(instancetype)initWithReachabilityRef:(SCNetworkReachabilityRef)ref
+{
+    self = [super init];
+    if (self != nil) 
+    {
+        self.reachableOnWWAN = YES;
+        self.reachabilityRef = ref;
+
+        // We need to create a serial queue.
+        // We allocate this once for the lifetime of the notifier.
+
+        self.reachabilitySerialQueue = dispatch_queue_create("com.tonymillion.reachability", NULL);
+    }
+    
+    return self;    
+}
+
+-(void)dealloc
+{
+    [self stopNotifier];
+
+    if(self.reachabilityRef)
+    {
+        CFRelease(self.reachabilityRef);
+        self.reachabilityRef = nil;
+    }
+
+	self.reachableBlock          = nil;
+    self.unreachableBlock        = nil;
+    self.reachabilityBlock       = nil;
+    self.reachabilitySerialQueue = nil;
+}
+
+#pragma mark - Notifier Methods
+
+// Notifier 
+// NOTE: This uses GCD to trigger the blocks - they *WILL NOT* be called on THE MAIN THREAD
+// - In other words DO NOT DO ANY UI UPDATES IN THE BLOCKS.
+//   INSTEAD USE dispatch_async(dispatch_get_main_queue(), ^{UISTUFF}) (or dispatch_sync if you want)
+
+-(BOOL)startNotifier
+{
+    // allow start notifier to be called multiple times
+    if(self.reachabilityObject && (self.reachabilityObject == self))
+    {
+        return YES;
+    }
+
+
+    SCNetworkReachabilityContext    context = { 0, NULL, NULL, NULL, NULL };
+    context.info = (__bridge void *)self;
+
+    if(SCNetworkReachabilitySetCallback(self.reachabilityRef, TMReachabilityCallback, &context))
+    {
+        // Set it as our reachability queue, which will retain the queue
+        if(SCNetworkReachabilitySetDispatchQueue(self.reachabilityRef, self.reachabilitySerialQueue))
+        {
+            // this should do a retain on ourself, so as long as we're in notifier mode we shouldn't disappear out from under ourselves
+            // woah
+            self.reachabilityObject = self;
+            return YES;
+        }
+        else
+        {
+#ifdef DEBUG
+            NSLog(@"SCNetworkReachabilitySetDispatchQueue() failed: %s", SCErrorString(SCError()));
+#endif
+
+            // UH OH - FAILURE - stop any callbacks!
+            SCNetworkReachabilitySetCallback(self.reachabilityRef, NULL, NULL);
+        }
+    }
+    else
+    {
+#ifdef DEBUG
+        NSLog(@"SCNetworkReachabilitySetCallback() failed: %s", SCErrorString(SCError()));
+#endif
+    }
+
+    // if we get here we fail at the internet
+    self.reachabilityObject = nil;
+    return NO;
+}
+
+-(void)stopNotifier
+{
+    // First stop, any callbacks!
+    SCNetworkReachabilitySetCallback(self.reachabilityRef, NULL, NULL);
+    
+    // Unregister target from the GCD serial dispatch queue.
+    SCNetworkReachabilitySetDispatchQueue(self.reachabilityRef, NULL);
+
+    self.reachabilityObject = nil;
+}
+
+#pragma mark - reachability tests
+
+// This is for the case where you flick the airplane mode;
+// you end up getting something like this:
+//Reachability: WR ct-----
+//Reachability: -- -------
+//Reachability: WR ct-----
+//Reachability: -- -------
+// We treat this as 4 UNREACHABLE triggers - really apple should do better than this
+
+#define testcase (kSCNetworkReachabilityFlagsConnectionRequired | kSCNetworkReachabilityFlagsTransientConnection)
+
+-(BOOL)isReachableWithFlags:(SCNetworkReachabilityFlags)flags
+{
+    BOOL connectionUP = YES;
+    
+    if(!(flags & kSCNetworkReachabilityFlagsReachable))
+        connectionUP = NO;
+    
+    if( (flags & testcase) == testcase )
+        connectionUP = NO;
+    
+#if	TARGET_OS_IPHONE
+    if(flags & kSCNetworkReachabilityFlagsIsWWAN)
+    {
+        // We're on 3G.
+        if(!self.reachableOnWWAN)
+        {
+            // We don't want to connect when on 3G.
+            connectionUP = NO;
+        }
+    }
+#endif
+    
+    return connectionUP;
+}
+
+-(BOOL)isReachable
+{
+    SCNetworkReachabilityFlags flags;  
+    
+    if(!SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+        return NO;
+    
+    return [self isReachableWithFlags:flags];
+}
+
+-(BOOL)isReachableViaWWAN 
+{
+#if	TARGET_OS_IPHONE
+
+    SCNetworkReachabilityFlags flags = 0;
+    
+    if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    {
+        // Check we're REACHABLE
+        if(flags & kSCNetworkReachabilityFlagsReachable)
+        {
+            // Now, check we're on WWAN
+            if(flags & kSCNetworkReachabilityFlagsIsWWAN)
+            {
+                return YES;
+            }
+        }
+    }
+#endif
+    
+    return NO;
+}
+
+-(BOOL)isReachableViaWiFi 
+{
+    SCNetworkReachabilityFlags flags = 0;
+    
+    if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    {
+        // Check we're reachable
+        if((flags & kSCNetworkReachabilityFlagsReachable))
+        {
+#if	TARGET_OS_IPHONE
+            // Check we're NOT on WWAN
+            if((flags & kSCNetworkReachabilityFlagsIsWWAN))
+            {
+                return NO;
+            }
+#endif
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
+
+// WWAN may be available, but not active until a connection has been established.
+// WiFi may require a connection for VPN on Demand.
+-(BOOL)isConnectionRequired
+{
+    return [self connectionRequired];
+}
+
+-(BOOL)connectionRequired
+{
+    SCNetworkReachabilityFlags flags;
+	
+	if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    {
+		return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
+	}
+    
+    return NO;
+}
+
+// Dynamic, on demand connection?
+-(BOOL)isConnectionOnDemand
+{
+	SCNetworkReachabilityFlags flags;
+	
+	if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    {
+		return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
+				(flags & (kSCNetworkReachabilityFlagsConnectionOnTraffic | kSCNetworkReachabilityFlagsConnectionOnDemand)));
+	}
+	
+	return NO;
+}
+
+// Is user intervention required?
+-(BOOL)isInterventionRequired
+{
+    SCNetworkReachabilityFlags flags;
+	
+	if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    {
+		return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
+				(flags & kSCNetworkReachabilityFlagsInterventionRequired));
+	}
+	
+	return NO;
+}
+
+
+#pragma mark - reachability status stuff
+
+-(NetworkStatus)currentReachabilityStatus
+{
+    if([self isReachable])
+    {
+        if([self isReachableViaWiFi])
+            return ReachableViaWiFi;
+        
+#if	TARGET_OS_IPHONE
+        return ReachableViaWWAN;
+#endif
+    }
+    
+    return NotReachable;
+}
+
+-(SCNetworkReachabilityFlags)reachabilityFlags
+{
+    SCNetworkReachabilityFlags flags = 0;
+    
+    if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags)) 
+    {
+        return flags;
+    }
+    
+    return 0;
+}
+
+-(NSString*)currentReachabilityString
+{
+	NetworkStatus temp = [self currentReachabilityStatus];
+	
+	if(temp == ReachableViaWWAN)
+	{
+        // Updated for the fact that we have CDMA phones now!
+		return NSLocalizedString(@"Cellular", @"");
+	}
+	if (temp == ReachableViaWiFi) 
+	{
+		return NSLocalizedString(@"WiFi", @"");
+	}
+	
+	return NSLocalizedString(@"No Connection", @"");
+}
+
+-(NSString*)currentReachabilityFlags
+{
+    return reachabilityFlags([self reachabilityFlags]);
+}
+
+#pragma mark - Callback function calls this method
+
+-(void)reachabilityChanged:(SCNetworkReachabilityFlags)flags
+{
+    if([self isReachableWithFlags:flags])
+    {
+        if(self.reachableBlock)
+        {
+            self.reachableBlock(self);
+        }
+    }
+    else
+    {
+        if(self.unreachableBlock)
+        {
+            self.unreachableBlock(self);
+        }
+    }
+    
+    if(self.reachabilityBlock)
+    {
+        self.reachabilityBlock(self, flags);
+    }
+    
+    // this makes sure the change notification happens on the MAIN THREAD
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:kReachabilityChangedNotification 
+                                                            object:self];
+    });
+}
+
+#pragma mark - Debug Description
+
+- (NSString *) description
+{
+    NSString *description = [NSString stringWithFormat:@"<%@: %#x (%@)>",
+                             NSStringFromClass([self class]), (unsigned int) self, [self currentReachabilityFlags]];
+    return description;
+}
+
+@end

--- a/Example/Castle/MainViewController.m
+++ b/Example/Castle/MainViewController.m
@@ -33,14 +33,14 @@
     NSURL *url = [NSURL URLWithString:@"https://google.com"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
     
-    // Get required headers from the Castle SDK if you don't want to use the request interceptor
-    [Castle.headers enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull value, BOOL * _Nonnull stop) {
-        [request addValue:value forHTTPHeaderField:key];
-    }];
+    // Get required header from the Castle SDK if you don't want to use the request interceptor
+    [request setValue:[Castle deviceIdentifier] forHTTPHeaderField:CASCastleDeviceIdHeaderKey];
     
     [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         NSLog(@"Response: %@, Error: %@", response, error);
     }] resume];
+    
+    [Castle flushIfNeeded:url];
 }
 
 - (IBAction)flush:(id)sender {


### PR DESCRIPTION
Removes the static headers method since there will never be more than one header value added. This also makes it easier to do manually add the header to requests when not using the request interceptor. 

There's also a new method flushIfNeeded which should be used after starting a new request. The method will flush if the provided url matches any of the base-urls in the whitelist.