### PR TITLE
Enforce max event queue limit

### DIFF
--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -49,5 +49,6 @@ extern NSString *const CastleClientIdHeaderName;
     
 + (NSString *)clientId;
 + (NSString *)userIdentity;
++ (NSUInteger)queueSize;
     
 @end

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -25,6 +25,7 @@ extern NSString *const CastleClientIdHeaderName;
     
 + (void)configure:(CastleConfiguration *)configuration;
 + (void)configureWithPublishableKey:(NSString *)publishableKey;
++ (void)resetConfiguration;
 + (NSURLSessionConfiguration *)urlSessionInterceptConfiguration;
 
 #pragma mark - Tracking

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -339,7 +339,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     }
 
     // Add event to the queue
-    CASLog(@"Qeueing event: %@", event);
+    CASLog(@"Queing event: %@", event);
     [self.eventQueue addObject:event];
 
     // Persist queue to disk
@@ -347,7 +347,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
     // Flush queue if the number of events exceeds the flush limit
     if(self.eventQueue.count >= self.configuration.flushLimit) {
-        // very first event should be fired immidtaley
+        // very first event should be fired immediately
         CASLog(@"Event queue exceeded flush limit (%ld). Flushing events.", [Castle sharedInstance].configuration.flushLimit);
         [self.class flush];
     }

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -108,6 +108,23 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [Castle configure:configuration];
 }
 
++ (void)resetConfiguration
+{
+    Castle *castle = [Castle sharedInstance];
+    CastleConfiguration *configuration = castle.configuration;
+    
+    // Reset Castle shared instance properties
+    castle.client = nil;
+    castle.configuration = nil;
+    castle.reachability = nil;
+    CASEnableDebugLogging(NO);
+    
+    // Unregister request interceptor
+    if(configuration.isDeviceIDAutoForwardingEnabled) {
+        [NSURLProtocol unregisterClass:[CASRequestInterceptor class]];
+    }
+}
+
 + (NSURLSessionConfiguration *)urlSessionInterceptConfiguration
 {
     NSURLSessionConfiguration *configuration = NSURLSessionConfiguration.defaultSessionConfiguration;

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -464,4 +464,9 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     return [Castle sharedInstance].userIdentity;
 }
 
++ (NSUInteger)queueSize
+{
+    return [Castle sharedInstance].eventQueue.count;
+}
+
 @end

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -84,12 +84,6 @@
 
     // Setup Castle SDK with publishable key
     [Castle configureWithPublishableKey:@"pk_SE5aTeotKZpDEn8kurzBYquRZyy21fvZ"];
-
-    // Set current app version to semething old
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:@"0.1.1" forKey:@"CastleAppVersionKey"];
-    [defaults synchronize];
-
     
     // Configuration reset
     [Castle resetConfiguration];
@@ -484,5 +478,22 @@
     // The queue size should still be equal to maxQueueLimit
     XCTAssertTrue(configuration.maxQueueLimit == [Castle queueSize]);
 }
+
+- (void)testAppUpdateDetection
+{
+    // Set current app version to semething old
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setObject:@"0.1.1" forKey:@"CastleAppVersionKey"];
+    [defaults synchronize];
+    
+    [Castle resetConfiguration];
+    [Castle configureWithPublishableKey:@"pk_SE5aTeotKZpDEn8kurzBYquRZyy21fvZ"];
+    
+    // Check to see if the installed version was updated correctly i.e. the SDK detected an app update.
+    NSString *currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *installedVersion = [defaults objectForKey:@"CastleAppVersionKey"];
+    XCTAssertEqual(currentVersion, installedVersion);
+}
+
 @end
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -371,6 +371,20 @@
 
 - (void)testRequestInterceptor
 {
+    // Create configuration object
+    CastleConfiguration *configuration = [CastleConfiguration configurationWithPublishableKey:@"pk_SE5aTeotKZpDEn8kurzBYquRZyy21fvZ"];
+    
+    NSArray *baseURLWhiteList = @[ [NSURL URLWithString:@"https://google.com/"] ];
+    
+    // Update configuration
+    configuration.screenTrackingEnabled = YES;
+    configuration.debugLoggingEnabled = YES;
+    configuration.deviceIDAutoForwardingEnabled = YES;
+    configuration.flushLimit = 10;
+    configuration.baseURLWhiteList = baseURLWhiteList;
+    
+    [Castle configure:configuration];
+    
     NSURLRequest *request1 = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://google.com/"]];
     XCTAssertTrue([CASRequestInterceptor canInitWithRequest:request1]);
     XCTAssertEqual([CASRequestInterceptor canonicalRequestForRequest:request1], request1);

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -48,8 +48,20 @@
 {
     NSArray *baseURLWhiteList = @[ [NSURL URLWithString:@"https://google.com/"] ];
 
+    // Make sure to reset configuration
+    [Castle resetConfiguration];
+    
     // Create configuration object
     CastleConfiguration *configuration = [CastleConfiguration configurationWithPublishableKey:@"pk_SE5aTeotKZpDEn8kurzBYquRZyy21fvZ"];
+    
+    // Check that all default values are set correctly
+    XCTAssertEqual(configuration.screenTrackingEnabled, YES);
+    XCTAssertEqual(configuration.debugLoggingEnabled, NO);
+    XCTAssertEqual(configuration.flushLimit, 20);
+    XCTAssertEqual(configuration.maxQueueLimit, 1000);
+    XCTAssertNil(configuration.baseURLWhiteList);
+    
+    // Update configuration
     configuration.screenTrackingEnabled = YES;
     configuration.debugLoggingEnabled = YES;
     configuration.deviceIDAutoForwardingEnabled = YES;
@@ -68,12 +80,6 @@
     [configuration setBaseURLWhiteList:@[ [NSURL URLWithString:@"https://google.com/somethingelse"]]];
     XCTAssertFalse([configuration.baseURLWhiteList[0].absoluteString isEqualToString:@"https://google.com/somethingelse"]);
 
-    XCTAssertTrue([Castle isWhitelistURL:[NSURL URLWithString:@"https://google.com/somethingelse"]]);
-    XCTAssertFalse([Castle isWhitelistURL:nil]);
-
-    // Setup Castle SDK with provided configuration
-    [Castle configure:configuration];
-    
     // Setup Castle SDK with publishable key
     [Castle configureWithPublishableKey:@"pk_SE5aTeotKZpDEn8kurzBYquRZyy21fvZ"];
 
@@ -82,8 +88,17 @@
     [defaults setObject:@"0.1.1" forKey:@"CastleAppVersionKey"];
     [defaults synchronize];
 
+    
+    // Configuration reset
+    [Castle resetConfiguration];
+    XCTAssertFalse([Castle isWhitelistURL:[NSURL URLWithString:@"https://google.com/somethingelse"]]);
+    
     // Setup Castle SDK with provided configuration
     [Castle configure:configuration];
+    
+    // Check whitelisting on configured instance
+    XCTAssertTrue([Castle isWhitelistURL:[NSURL URLWithString:@"https://google.com/somethingelse"]]);
+    XCTAssertFalse([Castle isWhitelistURL:nil]);
 }
 
 - (void)testReachabilityInit


### PR DESCRIPTION
Trim event queue when a new event is tracked and the queue exceeds maxQueueLimit removing the oldest event(s) stored in the queue.