### PR TITLE
Add support for secure mode

### DIFF
--- a/Castle/Classes/CASIdentity.m
+++ b/Castle/Classes/CASIdentity.m
@@ -56,7 +56,7 @@
     [payload removeObjectForKey:@"event"];
     [payload removeObjectForKey:@"properties"];
     
-    // Add user_id to payload and remove event property
+    // Override user_id property with the new userId and set properties for key traits
     [payload setObject:self.userId forKey:@"user_id"];
     [payload setObject:self.properties forKey:@"traits"];
     

--- a/Castle/Classes/CASIdentity.m
+++ b/Castle/Classes/CASIdentity.m
@@ -19,7 +19,7 @@
 + (instancetype)identityWithUserId:(NSString *)userId traits:(NSDictionary *)traits
 {
     if(userId.length == 0) {
-        CASLog(@"User id needs to be at least on character long");
+        CASLog(@"User id needs to be at least one character long");
         return nil;
     }
     

--- a/Castle/Classes/CASIdentity.m
+++ b/Castle/Classes/CASIdentity.m
@@ -50,14 +50,20 @@
 
 - (id)JSONPayload
 {
-    NSString *timestamp = [[CASModel timestampDateFormatter] stringFromDate:self.timestamp];
-    NSDictionary *context = [[CASContext sharedContext] JSONPayload];
+    NSMutableDictionary *payload = ((NSDictionary *) [super JSONPayload]).mutableCopy;
 
-    return @{ @"type": @"identify",
-              @"user_id": self.userId,
-              @"traits": self.properties,
-              @"timestamp": timestamp,
-              @"context": context };
+    // Add user_id to payload and remove event property
+    [payload setObject:self.userId forKey:@"user_id"];
+    [payload removeObjectForKey:@"event"];
+    
+    return [payload copy];
+}
+
+#pragma mark - Getters
+
+- (NSString *)type
+{
+    return @"identify";
 }
 
 @end

--- a/Castle/Classes/CASIdentity.m
+++ b/Castle/Classes/CASIdentity.m
@@ -52,9 +52,13 @@
 {
     NSMutableDictionary *payload = ((NSDictionary *) [super JSONPayload]).mutableCopy;
 
+    // Remove unneccessary data from payload
+    [payload removeObjectForKey:@"event"];
+    [payload removeObjectForKey:@"properties"];
+    
     // Add user_id to payload and remove event property
     [payload setObject:self.userId forKey:@"user_id"];
-    [payload removeObjectForKey:@"event"];
+    [payload setObject:self.properties forKey:@"traits"];
     
     return [payload copy];
 }

--- a/Castle/Classes/CASScreen.m
+++ b/Castle/Classes/CASScreen.m
@@ -59,20 +59,13 @@
 
 - (id)JSONPayload
 {
-    NSString *timestamp = [[CASModel timestampDateFormatter] stringFromDate:self.timestamp];
-    NSDictionary *context = [[CASContext sharedContext] JSONPayload];
+    NSMutableDictionary *payload = ((NSDictionary *) [super JSONPayload]).mutableCopy;
     
-    NSMutableDictionary *payload = @{ @"type": self.type,
-                                      @"name": self.name,
-                                      @"properties": self.properties,
-                                      @"timestamp": timestamp,
-                                      @"context": context }.mutableCopy;
+    // Add name to payload and remove event property
+    [payload setObject:self.name forKey:@"name"];
+    [payload removeObjectForKey:@"event"];
     
-    NSString *identity = [Castle userIdentity];
-    if(identity) {
-        payload[@"user_id"] = identity;
-    }
-    return payload.copy;
+    return [payload copy];
 }
 
 #pragma mark - Getters

--- a/Castle/Classes/Client/CASEvent.m
+++ b/Castle/Classes/Client/CASEvent.m
@@ -96,9 +96,9 @@
         payload[@"user_id"] = identity;
     }
     
-    NSString *signature = [Castle signature];
-    if(signature != nil) {
-        payload[@"signature"] = signature;
+    NSString *userSignature = [Castle userSignature];
+    if(userSignature != nil) {
+        payload[@"signature"] = userSignature;
     }
     
     return [payload copy];

--- a/Castle/Classes/Client/CASEvent.m
+++ b/Castle/Classes/Client/CASEvent.m
@@ -91,7 +91,7 @@
                                       @"timestamp": timestamp,
                                       @"context": context }.mutableCopy;
 
-    NSString *identity = [Castle userIdentity];
+    NSString *identity = [Castle userId];
     if(identity) {
         payload[@"user_id"] = identity;
     }

--- a/Castle/Classes/Client/CASEvent.m
+++ b/Castle/Classes/Client/CASEvent.m
@@ -95,7 +95,13 @@
     if(identity) {
         payload[@"user_id"] = identity;
     }
-    return payload.copy;
+    
+    NSString *signature = [Castle signature];
+    if(signature != nil) {
+        payload[@"signature"] = signature;
+    }
+    
+    return [payload copy];
 }
 
 #pragma mark - Getters

--- a/Castle/Classes/Client/CASEvent.m
+++ b/Castle/Classes/Client/CASEvent.m
@@ -98,7 +98,7 @@
     
     NSString *userSignature = [Castle userSignature];
     if(userSignature != nil) {
-        payload[@"signature"] = userSignature;
+        payload[@"user_signature"] = userSignature;
     }
     
     return [payload copy];

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -83,14 +83,14 @@ extern NSString *const CastleClientIdHeaderName;
 #pragma mark - Tracking
 
 /**
- Track identify event with specified user identity. User identity will be persisted. A call to identify or reset will clear the stored user identity.
+ Track identify event with specified user id. User identity will be persisted. A call to identify or reset will clear the stored user identity.
 
- @param identifier user id
- @code // Identify user with unique identifier
+ @param userId User Id
+ @code // Identify User with unique identifier
  [Castle identify:@"1245-3055"];
  @endcode
  */
-+ (void)identify:(NSString *)identifier;
++ (void)identify:(NSString *)userId;
 
 /**
  Track identify event with specified user identity. User identity will be persisted. A call to identify or reset will clear the stored user identity.
@@ -195,11 +195,11 @@ extern NSString *const CastleClientIdHeaderName;
 + (NSString *)clientId;
 
 /**
- Get stored user identity from last identify call, returns nil if not set
+ Get stored user id from last identify call, returns nil if not set
 
- @return User identity
+ @return User Id
  */
-+ (NSString *)userIdentity;
++ (NSString *)userId;
 
 /**
  Get stored signature from secure call, returns nil if not set

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -105,11 +105,11 @@ extern NSString *const CastleClientIdHeaderName;
 + (void)identify:(NSString *)identifier traits:(NSDictionary *)traits;
 
 /**
- Set signature and enable secure mode. Signature will be included in all events after it has been set and will be persisted.
- A stored signature will be removed when the signature or reset methods are called.
+ Set user signature and enable secure mode. User signature will be included in all events after it has been set and will be persisted.
+ A stored user signature will be removed when the user signature or reset methods are called.
  
- @param signature Signature (SHA-256 HMAC in hex format)
- @code // Add signature
+ @param signature User signature (SHA-256 HMAC in hex format)
+ @code // Add user signature
  [Castle signature:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
  @endcode
  */
@@ -206,7 +206,7 @@ extern NSString *const CastleClientIdHeaderName;
  
  @return Signature
  */
-+ (NSString *)signature;
++ (NSString *)userSignature;
 
 /**
  Get the current size of the event queue

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -103,6 +103,16 @@ extern NSString *const CastleClientIdHeaderName;
  @endcode
  */
 + (void)identify:(NSString *)identifier traits:(NSDictionary *)traits;
+/**
+ Set signature and enable secure mode. Signature will be included in all events after it has been set and will be persisted.
+ A stored signature will be removed when the signature or reset methods are called.
+ 
+ @param signature Signature (SHA-256 HMAC in hex format)
+ @code // Add signature
+ [Castle signature:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
+ @endcode
+ */
++ (void)secure:(NSString *)signature;
 
 /**
  Track event with a specified name
@@ -190,6 +200,12 @@ extern NSString *const CastleClientIdHeaderName;
  */
 + (NSString *)userIdentity;
 
+/**
+ Get stored signature from secure call, returns nil if not set
+ 
+ @return Signature
+ */
++ (NSString *)signature;
 
 /**
  Get the current size of the event queue

--- a/Castle/Classes/Public/Castle.h
+++ b/Castle/Classes/Public/Castle.h
@@ -103,6 +103,7 @@ extern NSString *const CastleClientIdHeaderName;
  @endcode
  */
 + (void)identify:(NSString *)identifier traits:(NSDictionary *)traits;
+
 /**
  Set signature and enable secure mode. Signature will be included in all events after it has been set and will be persisted.
  A stored signature will be removed when the signature or reset methods are called.

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -36,7 +36,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 @property (nonatomic, strong) CastleConfiguration *configuration;
 @property (nonatomic, strong) NSURLSessionDataTask *task;
 @property (nonatomic, strong) NSMutableArray *eventQueue;
-@property (nonatomic, copy, readwrite) NSString *userIdentity;
+@property (nonatomic, copy, readwrite) NSString *userId;
 @property (nonatomic, copy, readwrite) NSString *signature;
 @property (nonatomic, assign, readonly) NSUInteger maxBatchSize;
 @property (nonatomic, strong, readwrite) CASReachability *reachability;
@@ -44,7 +44,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
 @implementation Castle
 
-@synthesize userIdentity = _userIdentity;
+@synthesize userId = userId;
 @synthesize signature = _signature;
 
 + (instancetype)sharedInstance {
@@ -161,13 +161,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     return 100;
 }
 
-- (NSString *)userIdentity
+- (NSString *)userId
 {
-    // If there's no user identity: try fetching it from settings
-    if(!_userIdentity) {
-        _userIdentity = [[NSUserDefaults standardUserDefaults] objectForKey:CastleUserIdentifierKey];
+    // If there's no user id: try fetching it from settings
+    if(!_userId) {
+        _userId = [[NSUserDefaults standardUserDefaults] objectForKey:CastleUserIdentifierKey];
     }
-    return _userIdentity;
+    return _userId;
 }
 
 - (NSString *)signature
@@ -202,13 +202,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
 #pragma mark - Setters
 
-- (void)setUserIdentity:(NSString *)userIdentity
+- (void)setUserId:(NSString *)userId
 {
-    _userIdentity = userIdentity;
+    _userId = userId;
 
     // Store user identity in user defaults
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:userIdentity forKey:CastleUserIdentifierKey];
+    [defaults setObject:userId forKey:CastleUserIdentifierKey];
     [defaults synchronize];
 }
     
@@ -258,15 +258,15 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [castle queueEvent:screen];
 }
 
-+ (void)identify:(NSString *)identifier
++ (void)identify:(NSString *)userId
 {
-    [Castle identify:identifier traits:@{}];
+    [Castle identify:userId traits:@{}];
 }
 
-+ (void)identify:(NSString *)identifier traits:(NSDictionary *)traits
++ (void)identify:(NSString *)userId traits:(NSDictionary *)traits
 {
-    if(!identifier || [identifier isEqualToString:@""]) {
-        CASLog(@"No identifier provided. Will cancel identify operation.");
+    if(!userId || [userId isEqualToString:@""]) {
+        CASLog(@"No user id provided. Will cancel identify operation.");
         return;
     }
     
@@ -275,7 +275,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     }
 
     Castle *castle = [Castle sharedInstance];
-    [castle setUserIdentity:identifier];
+    [castle setUserId:identifier];
     CASIdentity *identity = [CASIdentity identityWithUserId:identifier traits:traits];
     [castle queueEvent:identity];
 
@@ -362,8 +362,8 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     // Flush queue
     [Castle flush];
 
-    // Reset cached identity
-    castle.userIdentity = nil;
+    // Reset cached user id
+    castle.userId = nil;
     
     // Reset cached signature
     castle.signature = nil;
@@ -504,9 +504,9 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     return [Castle sharedInstance].deviceIdentifier;
 }
 
-+ (NSString *)userIdentity
++ (NSString *)userId
 {
-    return [Castle sharedInstance].userIdentity;
+    return [Castle sharedInstance].userId;
 }
     
 + (NSString *)signature

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -44,7 +44,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
 @implementation Castle
 
-@synthesize userId = userId;
+@synthesize userId = _userId;
 @synthesize signature = _signature;
 
 + (instancetype)sharedInstance {
@@ -269,14 +269,14 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         CASLog(@"No user id provided. Will cancel identify operation.");
         return;
     }
-    
-    if(![self secureModeEnabled]) {
-        CASLog(@"Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
-    }
 
     Castle *castle = [Castle sharedInstance];
-    [castle setUserId:identifier];
-    CASIdentity *identity = [CASIdentity identityWithUserId:identifier traits:traits];
+    if(![castle secureModeEnabled]) {
+        CASLog(@"Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
+    }
+    
+    [castle setUserId:userId];
+    CASIdentity *identity = [CASIdentity identityWithUserId:userId traits:traits];
     [castle queueEvent:identity];
 
     // Identify call will always flush

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -275,12 +275,14 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         CASLog(@"Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
     }
     
-    [castle setUserId:userId];
     CASIdentity *identity = [CASIdentity identityWithUserId:userId traits:traits];
-    [castle queueEvent:identity];
-
-    // Identify call will always flush
-    [Castle flush];
+    if(identity != nil) {
+        [castle setUserId:userId];
+        [castle queueEvent:identity];
+        
+        // Identify call will always flush
+        [Castle flush];
+    }
 }
 
 + (void)secure:(NSString *)signature

--- a/Castle/Classes/Public/Castle.m
+++ b/Castle/Classes/Public/Castle.m
@@ -37,7 +37,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 @property (nonatomic, strong) NSURLSessionDataTask *task;
 @property (nonatomic, strong) NSMutableArray *eventQueue;
 @property (nonatomic, copy, readwrite) NSString *userId;
-@property (nonatomic, copy, readwrite) NSString *signature;
+@property (nonatomic, copy, readwrite) NSString *userSignature;
 @property (nonatomic, assign, readonly) NSUInteger maxBatchSize;
 @property (nonatomic, strong, readwrite) CASReachability *reachability;
 @end
@@ -45,7 +45,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 @implementation Castle
 
 @synthesize userId = _userId;
-@synthesize signature = _signature;
+@synthesize userSignature = _userSignature;
 
 + (instancetype)sharedInstance {
     static Castle *_sharedClient = nil;
@@ -170,13 +170,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     return _userId;
 }
 
-- (NSString *)signature
+- (NSString *)userSignature
 {
-    // If there's no signature: try fetching it from settings
-    if(!_signature) {
-        _signature = [[NSUserDefaults standardUserDefaults] objectForKey:CastleSecureSignatureKey];
+    // If there's no user signature: try fetching it from settings
+    if(!_userSignature) {
+        _userSignature = [[NSUserDefaults standardUserDefaults] objectForKey:CastleSecureSignatureKey];
     }
-    return _signature;
+    return _userSignature;
 }
 
 + (BOOL)isWifiAvailable
@@ -212,13 +212,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [defaults synchronize];
 }
     
-- (void)setSignature:(NSString *)signature
+- (void)setUserSignature:(NSString *)userSignature
 {
-    _signature = signature;
+    _userSignature = userSignature;
     
-    // Store signature in user defaults
+    // Store user signature in user defaults
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:signature forKey:CastleSecureSignatureKey];
+    [defaults setObject:userSignature forKey:CastleSecureSignatureKey];
     [defaults synchronize];
 }
 
@@ -272,7 +272,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
     Castle *castle = [Castle sharedInstance];
     if(![castle secureModeEnabled]) {
-        CASLog(@"Identify called without secure mode signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
+        CASLog(@"Identify called without secure mode user signature set. If secure mode is enabled in Castle and identify is called before secure, the identify event will be discarded.");
     }
     
     CASIdentity *identity = [CASIdentity identityWithUserId:userId traits:traits];
@@ -285,15 +285,15 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     }
 }
 
-+ (void)secure:(NSString *)signature
++ (void)secure:(NSString *)userSignature
 {
-    if(!signature || [signature isEqualToString:@""]) {
-        CASLog(@"No signature provided. Will cancel secure operation.");
+    if(!userSignature || [userSignature isEqualToString:@""]) {
+        CASLog(@"No user signature provided. Will cancel secure operation.");
         return;
     }
     
     Castle *castle = [Castle sharedInstance];
-    [castle setSignature:signature];
+    [castle setUserSignature:userSignature];
 }
 
 + (void)flush
@@ -368,7 +368,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     castle.userId = nil;
     
     // Reset cached signature
-    castle.signature = nil;
+    castle.userSignature = nil;
 }
 
 + (BOOL)isWhitelistURL:(NSURL *)url
@@ -467,7 +467,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
 - (BOOL)secureModeEnabled
 {
-    return self.signature != nil;
+    return self.userSignature != nil;
 }
 
 #pragma mark - Application Lifecycle
@@ -511,9 +511,9 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     return [Castle sharedInstance].userId;
 }
     
-+ (NSString *)signature
++ (NSString *)userSignature
 {
-    return [Castle sharedInstance].signature;
+    return [Castle sharedInstance].userSignature;
 }
 
 + (NSUInteger)queueSize

--- a/Example/Castle.xcodeproj/project.pbxproj
+++ b/Example/Castle.xcodeproj/project.pbxproj
@@ -209,7 +209,6 @@
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
 				6A830255F0946089742AFFDE /* [CP] Embed Pods Frameworks */,
-				218CD2C13A919B0076DEAB2E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -228,8 +227,6 @@
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				17BC09E5F008FDA30F9AB574 /* [CP] Embed Pods Frameworks */,
-				7D0D507CE5E703AD5A766970 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -319,36 +316,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		17BC09E5F008FDA30F9AB574 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Castle_Tests/Pods-Castle_Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		218CD2C13A919B0076DEAB2E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Castle_Example/Pods-Castle_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		44EF2C574D619824A6258C79 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -383,21 +350,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Castle_Example/Pods-Castle_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7D0D507CE5E703AD5A766970 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Castle_Tests/Pods-Castle_Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Castle (0.9.8)
+  - Castle (0.9.9)
 
 DEPENDENCIES:
   - Castle (from `../`)
 
 EXTERNAL SOURCES:
   Castle:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Castle: a41d13cae7ba2ed25d41e4973a7526194ba57efa
+  Castle: eb4d099410968028ea5e135a38c6d98b7ba03843
 
 PODFILE CHECKSUM: 2d5a43cae358afe6455ce7654c04994f0a3e13c2
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -320,7 +320,7 @@
     XCTAssertNotNil(payload[@"properties"]);
     XCTAssertNotNil(payload[@"timestamp"]);
     XCTAssertNotNil(payload[@"context"]);
-    XCTAssertNil(payload[@"signature"]);
+    XCTAssertNil(payload[@"user_signature"]);
     
     // Payload should not include these parameters
     XCTAssertNil(payload[@"event"]);
@@ -328,7 +328,7 @@
     // Check to see that user signature is included after secure mode is enabled
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     payload = [screen JSONPayload];
-    XCTAssertNotNil(payload[@"signature"]);
+    XCTAssertNotNil(payload[@"user_signature"]);
 }
 
 - (void)testObjectSerializationForIdentify
@@ -346,7 +346,7 @@
     XCTAssertTrue([payload[@"traits"] isEqualToDictionary:traits]);
     XCTAssertNotNil(payload[@"timestamp"]);
     XCTAssertNotNil(payload[@"context"]);
-    XCTAssertNil(payload[@"signature"]);
+    XCTAssertNil(payload[@"user_signature"]);
     
     // Payload should not include these parameters
     XCTAssertNil(payload[@"properties"]);
@@ -355,7 +355,7 @@
     // Check to see that user signature is included after secure mode is enabled
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     payload = [identity JSONPayload];
-    XCTAssertNotNil(payload[@"signature"]);
+    XCTAssertNotNil(payload[@"user_signature"]);
 }
 
 - (void)testObjectSerializationForEvent
@@ -384,7 +384,7 @@
     XCTAssertNotNil(payload[@"properties"]);
     XCTAssertNotNil(payload[@"timestamp"]);
     XCTAssertNotNil(payload[@"context"]);
-    XCTAssertNil(payload[@"signature"]);
+    XCTAssertNil(payload[@"user_signature"]);
 
     // Validate JSON Serialization success
     XCTAssertNotNil(event1.JSONData);
@@ -398,7 +398,7 @@
     // Check to see that user signature is included after secure mode is enabled
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     payload = [event1 JSONPayload];
-    XCTAssertNotNil(payload[@"signature"]);
+    XCTAssertNotNil(payload[@"user_signature"]);
 }
 
 - (void)testPersistance

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -200,6 +200,8 @@
 
 - (void)testTracking
 {
+    [Castle reset];
+    
     // This should lead to no event being tracked since empty string isn't a valid name
     NSUInteger count = [CASEventStorage storedQueue].count;
     [Castle track:@""];
@@ -222,13 +224,15 @@
     count = [CASEventStorage storedQueue].count;
     [Castle identify:@""];
     newCount = [CASEventStorage storedQueue].count;
-    XCTAssertTrue(count == newCount);
+    XCTAssertTrue(count == newCount); // Count should be unchanced
+    XCTAssertNil([Castle userId]); // User id should be nil
 
     // This should lead to no event being tracked properties can't be nil
     count = [CASEventStorage storedQueue].count;
     [Castle identify:@"testuser1" traits:nil];
     newCount = [CASEventStorage storedQueue].count;
-    XCTAssertTrue(count == newCount);
+    XCTAssertTrue(count == newCount); // Count should be unchanced
+    XCTAssertNil([Castle userId]); // User id should be nil
 
     CASScreen *screen = [CASScreen eventWithName:@"Main"];
     XCTAssertNotNil(screen);

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -185,17 +185,17 @@
     // Call secure to save the signature
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     
-    // Check that the stored signature is the same as the signature we provided
-    XCTAssertEqual([Castle signature], @"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
+    // Check that the stored user signature is the same as the user signature we provided
+    XCTAssertEqual([Castle userSignature], @"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
 }
 
 - (void)testReset
 {
     [Castle reset];
 
-    // Check to see if the user id and signature was cleared on reset
+    // Check to see if the user id and user signature was cleared on reset
     XCTAssertNil([Castle userId]);
-    XCTAssertNil([Castle signature]);
+    XCTAssertNil([Castle userSignature]);
 }
 
 - (void)testTracking
@@ -291,17 +291,17 @@
 
 - (void)testSecureMode
 {
-    // Calling secure with a nil signature should not store or replace any previous signature
+    // Calling secure with a nil user signature should not store or replace any previous signature
     [Castle secure:nil];
-    XCTAssertNil([Castle signature]);
+    XCTAssertNil([Castle userSignature]);
     
-    // Signature should be stored
+    // User signature should be stored
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
-    XCTAssertEqual([Castle signature], @"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
+    XCTAssertEqual([Castle userSignature], @"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
     
     // Calling secure again should override previously stored signature
     [Castle secure:@"844d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
-    XCTAssertEqual([Castle signature], @"844d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
+    XCTAssertEqual([Castle userSignature], @"844d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52");
 }
 
 - (void)testObjectSerializationForScreen
@@ -325,7 +325,7 @@
     // Payload should not include these parameters
     XCTAssertNil(payload[@"event"]);
     
-    // Check to see that signature is included after secure mode is enabled
+    // Check to see that user signature is included after secure mode is enabled
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     payload = [screen JSONPayload];
     XCTAssertNotNil(payload[@"signature"]);
@@ -352,7 +352,7 @@
     XCTAssertNil(payload[@"properties"]);
     XCTAssertNil(payload[@"event"]);
     
-    // Check to see that signature is included after secure mode is enabled
+    // Check to see that user signature is included after secure mode is enabled
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     payload = [identity JSONPayload];
     XCTAssertNotNil(payload[@"signature"]);
@@ -395,7 +395,7 @@
     CASEvent *invalidEvent2 = [CASEvent eventWithName:@"testevent2" properties:@{ @"invalidParamContainer": @{ @"invalidParam": [[NSObject alloc] init] } }];
     XCTAssertNil(invalidEvent2);
     
-    // Check to see that signature is included after secure mode is enabled
+    // Check to see that user signature is included after secure mode is enabled
     [Castle secure:@"944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52"];
     payload = [event1 JSONPayload];
     XCTAssertNotNil(payload[@"signature"]);

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -177,7 +177,7 @@
     [Castle identify:@"thisisatestuser"];
 
     // Check that the stored identity is the same as the identity we tracked
-    XCTAssertEqual([Castle userIdentity], @"thisisatestuser");
+    XCTAssertEqual([Castle userId], @"thisisatestuser");
 }
 
 - (void)testReset
@@ -185,7 +185,7 @@
     [Castle reset];
 
     // Check to see if the user identity was cleared on reset
-    XCTAssertNil([Castle userIdentity]);
+    XCTAssertNil([Castle userId]);
 }
 
 - (void)testTracking


### PR DESCRIPTION
This pull request adds support for secure mode as well removing some code duplication for CASEvent JSON payload generation.

A new method `secure` has been added to the public API. Calling this method will set the user signature and store it locally on the device. Here's an example:

```swift
Castle.secure("944d7d6c5187cafac297785bbf6de0136a2e10f31788e92b2822f5cfd407fa52")
```

The signature will be included in all events sent from that point forward. Calling `reset` will clear any stored user signature and calling `secure` again will replace the current user signature.