### PR TITLE
Set locale for timestamp date formatter to en-US.

### DIFF
--- a/Castle/Classes/CASModel.m
+++ b/Castle/Classes/CASModel.m
@@ -43,6 +43,7 @@
     dispatch_once(&onceToken, ^{
         _timestampDateFormatter = [[NSDateFormatter alloc] init];
         [_timestampDateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+        [_timestampDateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US"]];
         [_timestampDateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
     });
     return _timestampDateFormatter;


### PR DESCRIPTION
Set locale to en-US for CASModel date formatter to ensure that the timestamp format remains the same independent on the users current locale.