### PR TITLE
Fix/userid persistence consistency

### DIFF
--- a/Castle/Classes/CASIdentity.h
+++ b/Castle/Classes/CASIdentity.h
@@ -9,8 +9,6 @@
 
 @interface CASIdentity : CASEvent
 
-@property (nonatomic, copy, readonly) NSString * _Nonnull userId;
-
 + (instancetype _Nullable)identityWithUserId:(NSString * _Nonnull)userId traits:(NSDictionary * _Nonnull)traits;
 
 @end

--- a/Castle/Classes/CASIdentity.m
+++ b/Castle/Classes/CASIdentity.m
@@ -16,6 +16,8 @@
 
 @implementation CASIdentity
 
+@synthesize userId = _userId;
+
 + (instancetype)identityWithUserId:(NSString *)userId traits:(NSDictionary *)traits
 {
     if(userId.length == 0) {
@@ -26,24 +28,6 @@
     CASIdentity *identity = (CASIdentity *) [super eventWithName:@"identify" properties:traits];
     identity.userId = userId;
     return identity;
-}
-
-#pragma mark - NSCoding
-
-- (id)initWithCoder:(NSCoder *)decoder
-{
-    self = [super initWithCoder:decoder];
-    if(self) {
-        self.userId = [decoder decodeObjectOfClass:NSString.class forKey:@"userId"];
-    }
-    return self;
-}
-
-- (void)encodeWithCoder:(NSCoder *)encoder
-{
-    [super encodeWithCoder:encoder];
-    
-    [encoder encodeObject:self.userId forKey:@"userId"];
 }
 
 #pragma mark - CASModel

--- a/Castle/Classes/CASScreen.m
+++ b/Castle/Classes/CASScreen.m
@@ -48,10 +48,7 @@
         return nil;
     }
     
-    CASScreen *screen = [[self alloc] init];
-    screen.name = name;
-    screen.properties = properties;
-    screen.timestamp = [NSDate date];
+    CASScreen *screen = (CASScreen *) [super eventWithName:name properties:properties];
     return screen;
 }
 

--- a/Castle/Classes/Client/CASEvent.h
+++ b/Castle/Classes/Client/CASEvent.h
@@ -15,6 +15,8 @@
 @property (nonatomic, copy, readonly) NSDictionary *properties;
 @property (nonatomic, copy, readonly) NSDate *timestamp;
 @property (nonatomic, copy, readonly) NSString *type;
+@property (nonatomic, copy, readonly) NSString *userId;
+@property (nonatomic, copy, readonly) NSString *userSignature;
 
 + (instancetype)eventWithName:(NSString *)name;
 + (instancetype)eventWithName:(NSString *)name properties:(NSDictionary *)properties;

--- a/Castle/Classes/Client/CASEvent.m
+++ b/Castle/Classes/Client/CASEvent.m
@@ -15,6 +15,8 @@
 @property (nonatomic, copy, readwrite) NSString *name;
 @property (nonatomic, copy, readwrite) NSDictionary *properties;
 @property (nonatomic, copy, readwrite) NSDate *timestamp;
+@property (nonatomic, copy, readwrite) NSString *userId;
+@property (nonatomic, copy, readwrite) NSString *userSignature;
 @end
 
 @implementation CASEvent
@@ -47,8 +49,20 @@
     CASEvent *event = [[self alloc] init];
     event.name = name;
     event.properties = properties;
-    event.timestamp = [NSDate date];
     return event;
+}
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+    if(self) {
+        self.timestamp = [NSDate date];
+        self.userId = [Castle userId];
+        self.userSignature = [Castle userSignature];
+    }
+    return self;
 }
 
 #pragma mark - NSCoding
@@ -60,6 +74,9 @@
         self.name = [decoder decodeObjectOfClass:NSString.class forKey:@"name"];
         self.properties = [decoder decodeObjectOfClass:NSDictionary.class forKey:@"properties"];
         self.timestamp = [decoder decodeObjectOfClass:NSDate.class forKey:@"timestamp"];
+        self.userId = [decoder decodeObjectOfClass:NSString.class forKey:@"user_id"];
+        self.userSignature = [decoder decodeObjectOfClass:NSString.class forKey:@"user_signature"];
+        
     }
     return self;
 }
@@ -69,6 +86,8 @@
     [encoder encodeObject:self.name forKey:@"name"];
     [encoder encodeObject:self.properties forKey:@"properties"];
     [encoder encodeObject:self.timestamp forKey:@"timestamp"];
+    [encoder encodeObject:self.userId forKey:@"user_id"];
+    [encoder encodeObject:self.userSignature forKey:@"user_signature"];
 }
 
 #pragma mark - NSSecureCoding
@@ -91,14 +110,12 @@
                                       @"timestamp": timestamp,
                                       @"context": context }.mutableCopy;
 
-    NSString *identity = [Castle userId];
-    if(identity) {
-        payload[@"user_id"] = identity;
+    if(self.userId != nil) {
+        payload[@"user_id"] = self.userId;
     }
     
-    NSString *userSignature = [Castle userSignature];
-    if(userSignature != nil) {
-        payload[@"user_signature"] = userSignature;
+    if(self.userSignature != nil) {
+        payload[@"user_signature"] = self.userSignature;
     }
     
     return [payload copy];


### PR DESCRIPTION
Make sure to use the stored user id and user signature for an event when creating the JSON payload. The user id and signature should **never** change after the event object is created.