### PR TITLE
Remove vendor and example from code coverage

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -15,9 +15,6 @@
 #import <Castle/CASRequestInterceptor.h>
 #import <Castle/CASAPIClient.h>
 #import <Castle/UIViewController+CASScreen.h>
-#import <Castle/CASReachability.h>
-
-#include <arpa/inet.h>
 
 #import "MainViewController.h"
 
@@ -95,74 +92,6 @@
     // Check whitelisting on configured instance
     XCTAssertTrue([Castle isWhitelistURL:[NSURL URLWithString:@"https://google.com/somethingelse"]]);
     XCTAssertFalse([Castle isWhitelistURL:nil]);
-}
-
-- (void)testReachabilityInit
-{
-    CASReachability *reachability = [CASReachability reachabilityForLocalWiFi];
-    XCTAssertNotNil(reachability);
-    
-    reachability = [CASReachability reachabilityForInternetConnection];
-    XCTAssertNotNil(reachability);
-    
-    struct sockaddr_in address;
-    address.sin_len = sizeof(address);
-    address.sin_family = AF_INET;
-    address.sin_port = htons(8080);
-    address.sin_addr.s_addr = inet_addr("216.58.199.174"); // Google IP
-    reachability = [CASReachability reachabilityWithAddress:&address];
-    XCTAssertNotNil(reachability);
-}
-
-- (void)testReachabilityValidHostname
-{
-    // Test valid Host name
-    CASReachability *reachability = [CASReachability reachabilityWithHostName:@"google.com"];
-    XCTAssertNotNil(reachability);
-    
-    // Test reachable getters
-    XCTAssertTrue([reachability reachableOnWWAN]);
-    XCTAssertTrue([reachability isReachableViaWiFi]);
-    XCTAssertTrue([reachability isReachable]);
-    
-    XCTAssertFalse([reachability isConnectionRequired]);
-    XCTAssertFalse([reachability isConnectionOnDemand]);
-    XCTAssertFalse([reachability isInterventionRequired]);
-    
-    XCTAssertNotNil([reachability currentReachabilityString]);
-    XCTAssertNotNil([reachability currentReachabilityFlags]);
-    XCTAssertNotNil([reachability description]);
-    
-    XCTAssertTrue([reachability currentReachabilityStatus] != NotReachable);
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachable expectation"];
-    [reachability setReachableBlock:^(CASReachability *reachability) {
-        [expectation fulfill];
-    }];
-    
-    [reachability startNotifier];
-   
-    [self waitForExpectationsWithTimeout:5 handler:nil];
-    
-    [reachability stopNotifier];
-}
-
-- (void)testReachabilityInvalidHostname
-{
-    // Test invalid Host name
-    CASReachability *reachability = [CASReachability reachabilityWithHostName:@"invalidhost"];
-    XCTAssertNotNil(reachability);
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Unreachable expectation"];
-    [reachability setUnreachableBlock:^(CASReachability *reachability) {
-        [expectation fulfill];
-    }];
-    
-    [reachability startNotifier];
-    
-    [self waitForExpectationsWithTimeout:5 handler:nil];
-    
-    [reachability stopNotifier];
 }
 
 - (void)testDeviceIdentifier

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,3 +25,4 @@ comment:
 
 ignore:
   - Example/Pods
+  - Castle/Classes/Reachability

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,5 +24,5 @@ comment:
   behavior: default  # update if exists else create new
 
 ignore:
-  - Example/Pods
   - Castle/Classes/Reachability
+  - Example


### PR DESCRIPTION
Don't include the example or vendor files (Reachability) in code coverage report on Codecov.io.