### PR TITLE
Fix/keyedarchiver depracated API

### DIFF
--- a/Castle/Classes/CASEventStorage.m
+++ b/Castle/Classes/CASEventStorage.m
@@ -23,7 +23,17 @@
 + (void)persistQueue:(NSArray *)queue
 {
     [self.class createStoragePathIfNeccessary];
-    BOOL persisted = [NSKeyedArchiver archiveRootObject:queue toFile:self.storagePath];
+    
+    BOOL persisted = NO;
+    if (@available(iOS 11.0, *)) {
+        NSError *error = nil;
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:queue requiringSecureCoding:YES error:&error];
+        if(data != nil && error == nil) {
+            persisted = [data writeToFile:self.storagePath atomically:YES];
+        }
+    } else {
+        persisted = [NSKeyedArchiver archiveRootObject:queue toFile:self.storagePath];
+    }
     
     if(persisted) {
         CASLog(@"%ld events written to: %@", queue.count, self.storagePath);

--- a/Example/Castle.xcodeproj/project.pbxproj
+++ b/Example/Castle.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Castle/Castle-Prefix.pch";
 				INFOPLIST_FILE = "Castle/Castle-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -541,7 +541,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Castle/Castle-Prefix.pch";
 				INFOPLIST_FILE = "Castle/Castle-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Only use [NSKeyedArchiver archiveRootObject:toFile] on iOS versions below 11.0.