### PR TITLE
Remove device name from event payload

### DIFF
--- a/Castle/Classes/CASDevice.m
+++ b/Castle/Classes/CASDevice.m
@@ -31,7 +31,6 @@
     return @{ @"model": [CASDevice deviceModel],
               @"manufacturer": @"Apple",
               @"id": [Castle clientId],
-              @"name": [[UIDevice currentDevice] name],
               @"type": UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? @"tablet" : @"phone" };
 }
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -293,6 +293,9 @@
     XCTAssertNotNil(payload[@"context"]);
     XCTAssertNil(payload[@"user_signature"]);
     
+    // Device name should not be included
+    XCTAssertNil(payload[@"device"][@"name"]);
+    
     // Payload should not include these parameters
     XCTAssertNil(payload[@"event"]);
     


### PR DESCRIPTION
Remove the current device name from the device section of the event payload.