### PR TITLE
Set custom timeout for all API requests

### DIFF
--- a/Castle/Classes/Client/CASAPIClient.m
+++ b/Castle/Classes/Client/CASAPIClient.m
@@ -136,6 +136,9 @@ NSString *const CASAPIClientVersion = @"v1";
     // Set custom User Agent
     [request setValue:[Castle userAgent] forHTTPHeaderField:@"User-Agent"];
     
+    // Set timeout
+    [request setTimeoutInterval:10.0f];
+    
     // Authentication
     NSString *authStr = [NSString stringWithFormat:@":%@", self.configuration.publishableKey];
     NSData *authData = [authStr dataUsingEncoding:NSASCIIStringEncoding];


### PR DESCRIPTION
Set timeout to 10 seconds (default 60) for all API requests.