### PR TITLE
User agent validation test

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -78,7 +78,7 @@
 - (void)testUserAgent
 {
     NSString *userAgent = [Castle userAgent];
-    NSString *pattern = @"[a-zA-Z0-9\\s_-]+\\/[0-9]+\\.[0-9]+ \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; iOS [0-9]+\\.[0-9]+; Castle [0-9]+\\.[0-9]+\\.[0-9]+\\)";
+    NSString *pattern = @"[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; iOS [0-9]+\\.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*\\)";
     NSError *error = nil;
     
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];


### PR DESCRIPTION
Valid app versions and Castle versions could be in either x.x.x or x.x format. Previous test failed when app version or Castle version only consisted of two numbers (x.x).