### PR TITLE
Remove duplicate time zone in context payload

### DIFF
--- a/Castle/Classes/CASContext.m
+++ b/Castle/Classes/CASContext.m
@@ -28,8 +28,6 @@
 {
     NSMutableDictionary *context = [NSMutableDictionary dictionaryWithObject:[[CASDevice sharedDevice] JSONPayload] forKey:@"device"];
     
-    context[@"timezone"] = [NSTimeZone systemTimeZone].name;
-    
     NSLocale *locale = [NSLocale currentLocale];
     context[@"locale"] = [NSString stringWithFormat:@"%@-%@", [locale objectForKey:NSLocaleLanguageCode], [locale objectForKey:NSLocaleCountryCode]];
     


### PR DESCRIPTION
Remove ```[NSTimeZone systemTimeZone].name``` when building the context payload since it's always overwritten by ```[NSTimeZone localTimeZone].name```. 

This change will have no effect on the actual value of timezone from previous releases since it has always been overwritten by ```[NSTimeZone localTimeZone].name```.