### PR TITLE
User agent should include device model not device name.

### DIFF
--- a/Castle/Classes/Util/CASUtils.m
+++ b/Castle/Classes/Util/CASUtils.m
@@ -37,9 +37,9 @@ NSString *CASUserAgent(void)
     
     // Gather device information
     UIDevice *device = [UIDevice currentDevice];
-    NSString *deviceName = [device name];
+    NSString *model = [device name];
     NSString *system = [device systemName];
     NSString *systemVersion = [device systemVersion];
     
-    return [NSString stringWithFormat:@"%@/%@ (%@) (%@; %@ %@; Castle %@)", name, version, build, deviceName, system, systemVersion, [Castle versionString]];
+    return [NSString stringWithFormat:@"%@/%@ (%@) (%@; %@ %@; Castle %@)", name, version, build, model, system, systemVersion, [Castle versionString]];
 }


### PR DESCRIPTION
The user agent should not include the device name (for example "Alexander's iPhone"). It should include the device model instead ("iPhone XR" or similar).