### PR TITLE
Include model version in user agent string.

### DIFF
--- a/Castle/Classes/Util/CASUtils.m
+++ b/Castle/Classes/Util/CASUtils.m
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <sys/utsname.h>
 
 #import "CASUtils.h"
 #import "Castle.h"
@@ -28,6 +29,17 @@ void CASLog(NSString *format, ...)
     }
 }
 
+NSString *CASDeviceModel(void)
+{
+#if TARGET_OS_SIMULATOR
+    return [[NSProcessInfo processInfo] environment][@"SIMULATOR_MODEL_IDENTIFIER"];
+#else
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    return [NSString stringWithCString: systemInfo.machine encoding: NSUTF8StringEncoding];
+#endif
+}
+
 NSString *CASUserAgent(void)
 {
     // Get host app version information from the main bundle
@@ -38,7 +50,7 @@ NSString *CASUserAgent(void)
     
     // Gather device information
     UIDevice *device = [UIDevice currentDevice];
-    NSString *model = [device model];
+    NSString *model = CASDeviceModel();
     NSString *system = [device systemName];
     NSString *systemVersion = [device systemVersion];
     

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -79,7 +79,7 @@
 - (void)testUserAgent
 {
     NSString *userAgent = [Castle userAgent];
-    NSString *pattern = @"[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s]+; iOS [0-9]+\\.?[0-9]+.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*\\)";
+    NSString *pattern = @"[a-zA-Z0-9\\s._-]+/[0-9]+\\.[0-9]+\\.?[0-9]* \\([a-zA-Z0-9-_.]+\\) \\([a-zA-Z0-9\\s,]+; iOS [0-9]+\\.?[0-9]+.?[0-9]*; Castle [0-9]+\\.[0-9]+\\.?[0-9]*\\)";
     NSError *error = nil;
     
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];


### PR DESCRIPTION
Our UserAgent generator in the iOS SDK is currently generating something like:

AwesomeAppName/2.73.0 (231) (iPhone; iOS 14.2; Castle 1.0.5)

Extract the iPhone model code as well, eg. AwesomeAppName/2.73.0 (231) (iPhone12,1; iOS 14.2; Castle 1.0.5)