### PR TITLE
Remove COCOAPODS macro check from Castle.h

### DIFF
--- a/Castle/Public/Castle.h
+++ b/Castle/Public/Castle.h
@@ -15,11 +15,7 @@ FOUNDATION_EXPORT double CastleVersionNumber;
  Project version string for Castle. */
 FOUNDATION_EXPORT const unsigned char CastleVersionString[];
 
-#if COCOAPODS
-#import <Castle/CastleConfiguration.h>
-#else
 #import "CastleConfiguration.h"
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Proposed fix for #69.

This uses a single import for both SwiftPM and Cocoapods. It's unclear to me why this was changed in the past, so perhaps there's a valid reason why we can't `#import` in this way.

I've tested this with Castle as a SwiftPM dependency in our app (uses both Cocoapods and SwiftPM packages) and it no longer has the import error.

Also tested as a Cocoapods dependency in a test project and it works as expected.

We don't use Carthage, so I can't verify that this doesn't affect importing via Cartfile, so that would need to be tested.