### PR TITLE
PrivacyInfo project include, fix "Multiple commands produce ... PrivacyInfo.xcprivacy" error

### DIFF
--- a/Castle.xcodeproj/project.pbxproj
+++ b/Castle.xcodeproj/project.pbxproj
@@ -40,8 +40,7 @@
 		B69885A526124853009D4CD9 /* Castle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6B355DC1ED71D9700C2B817 /* Castle.framework */; platformFilter = ios; };
 		B6988627261348B6009D4CD9 /* GeoZip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6988625261348B6009D4CD9 /* GeoZip.xcframework */; };
 		B6988628261348B6009D4CD9 /* Highwind.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6988626261348B6009D4CD9 /* Highwind.xcframework */; };
-		B6AED34F2BBC41FA00A41CA9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B6AED34E2BBC41F800A41CA9 /* PrivacyInfo.xcprivacy */; };
-		B6AED3512BBC421000A41CA9 /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = B6AED34E2BBC41F800A41CA9 /* PrivacyInfo.xcprivacy */; };
+		B69AED292BBEC37C005727AE /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = B6AED34E2BBC41F800A41CA9 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,7 +60,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
-				B6AED3512BBC421000A41CA9 /* PrivacyInfo.xcprivacy in CopyFiles */,
+				B69AED292BBEC37C005727AE /* PrivacyInfo.xcprivacy in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,7 +340,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6AED34F2BBC41FA00A41CA9 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Castle/PrivacyInfo.xcprivacy
+++ b/Castle/PrivacyInfo.xcprivacy
@@ -5,7 +5,7 @@
 	<key>NSPrivacyTracking</key>
 	<false/>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array />
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Castle (3.0.9)
+  - Castle (3.0.10)
 
 DEPENDENCIES:
   - Castle (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Castle: 35662b72926688bc23e6fbcaf77d6e3ba3125e8a
+  Castle: 802a3327c0ecbcc24db47956a6e98709a162b33a
 
 PODFILE CHECKSUM: fd779497087cf3c675d35358fb1be87dabb6269c
 


### PR DESCRIPTION
Remove PrivacyInfo.xcprivacy from Resources, include in CopyFiles build step.