### PR TITLE
CVE-2024-43398: Upgrade rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,8 +169,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.9)
-      strscan
+    rexml (3.3.7)
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -183,7 +182,6 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
-    strscan (3.1.0)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -199,13 +197,13 @@ GEM
     unicode-display_width (1.8.0)
     webrick (1.8.1)
     word_wrap (1.0.0)
-    xcodeproj (1.22.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.2, < 4.0)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -222,4 +220,4 @@ DEPENDENCIES
   fastlane-plugin-create_xcframework
 
 BUNDLED WITH
-   2.5.15
+   2.5.18


### PR DESCRIPTION
[CVE-2024-43398](https://github.com/castle/castle-ios/security/dependabot/4): Upgrade rexml
